### PR TITLE
Fix volume size update issue

### DIFF
--- a/powermax/helper/volume_helper.go
+++ b/powermax/helper/volume_helper.go
@@ -122,7 +122,7 @@ func UpdateVol(ctx context.Context, client *client.Client, planVol, stateVol mod
 		}
 	}
 
-	if planVol.Size.ValueBigFloat() != stateVol.Size.ValueBigFloat() || planVol.CapUnit.ValueString() != stateVol.CapUnit.ValueString() {
+	if planVol.Size.ValueBigFloat().Cmp(stateVol.Size.ValueBigFloat()) != 0 || planVol.CapUnit.ValueString() != stateVol.CapUnit.ValueString() {
 		size, err := GetVolumeSize(planVol)
 		if err != nil {
 			updateFailedParameters = append(updateFailedParameters, "size")


### PR DESCRIPTION
Use Cmp() for comparing big.Float type

Now the capacity will not be mistakenly judged as needing to be updated:
```
Terraform will perform the following actions:

  # powermax_volume.volume_test will be updated in-place
  ~ resource "powermax_volume" "volume_test" {
      ~ allocated_percent      = 0 -> (known after apply)
      ~ effective_wwn          = "600009700bcbc0ec512d00cd0000001b" -> (known after apply)
      ~ emulation              = "FBA" -> (known after apply)
      ~ encapsulated           = false -> (known after apply)
      ~ has_effective_wwn      = false -> (known after apply)
      ~ id                     = "0016F" -> (known after apply)
      ~ mobility_id_enabled    = true -> (known after apply)
      ~ nguid                  = "512d00cd0000001b000097600bcbc0ec" -> (known after apply)
      ~ num_of_front_end_paths = 0 -> (known after apply)
      ~ num_of_storage_groups  = 1 -> (known after apply)
      ~ pinned                 = false -> (known after apply)
      ~ rdf_group_ids          = [] -> (known after apply)
      ~ reserved               = false -> (known after apply)
      ~ snapvx_source          = false -> (known after apply)
      ~ snapvx_target          = false -> (known after apply)
      ~ ssid                   = "FFFFFFFF" -> (known after apply)
      ~ status                 = "Ready" -> (known after apply)
      ~ type                   = "TDEV" -> (known after apply)
      + unreducible_data_gb    = (known after apply)
      ~ vol_name               = "test_acc_create_volume_2" -> "test_acc_create_volume_1"
      ~ wwn                    = "600009700bcbc0ec512d00cd0000001b" -> (known after apply)
        # (5 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

powermax_volume.volume_test: Modifying... [id=0016F]
powermax_volume.volume_test: Modifications complete after 5s [id=0016F]

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.
```