### PR TITLE
[ISSUE-47] Host_Group without host-flags

### DIFF
--- a/docs/resources/hostgroup.md
+++ b/docs/resources/hostgroup.md
@@ -34,13 +34,13 @@ Resource for managing HostGroups for a PowerMax Array
 
 ### Required
 
-- `host_flags` (Attributes) Host Flags set for the hostgroup. When host_flags = {} then default flags will be considered. (see [below for nested schema](#nestedatt--host_flags))
 - `host_ids` (Set of String) The masking views associated with the hostgroup.
 - `name` (String) The name of the hostgroup.
 
 ### Optional
 
 - `consistent_lun` (Boolean) It enables the rejection of any masking operation involving this hostgroup that would result in inconsistent LUN values.
+- `host_flags` (Attributes) Host Flags set for the hostgroup. When host_flags = {} or not set then default flags will be considered. (see [below for nested schema](#nestedatt--host_flags))
 
 ### Read-Only
 

--- a/examples/resources/hostgroup/resource.tf
+++ b/examples/resources/hostgroup/resource.tf
@@ -1,5 +1,6 @@
 // Copyright ©2023 Dell Inc. or its subsidiaries. All Rights Reserved.
 resource "powermax_hostgroup" "test_host_group" {
+  # Optional
   host_flags = {
     avoid_reset_broadcast = {
       enabled  = true

--- a/powermax/helper/hostgroup_helper.go
+++ b/powermax/helper/hostgroup_helper.go
@@ -75,22 +75,40 @@ func setHostFlagsInHg(flags string, isEnabled bool, hostState *models.HostGroupM
 }
 
 func setDefaultHostFlagsForHostGroup(hostState *models.HostGroupModel) {
-	hostState.HostFlags.VolumeSetAddressing.Enabled = basetypes.NewBoolValue(false)
-	hostState.HostFlags.VolumeSetAddressing.Override = basetypes.NewBoolValue(false)
-	hostState.HostFlags.DisableQResetOnUA.Enabled = basetypes.NewBoolValue(false)
-	hostState.HostFlags.DisableQResetOnUA.Override = basetypes.NewBoolValue(false)
-	hostState.HostFlags.AvoidResetBroadcast.Enabled = basetypes.NewBoolValue(false)
-	hostState.HostFlags.AvoidResetBroadcast.Override = basetypes.NewBoolValue(false)
-	hostState.HostFlags.EnvironSet.Enabled = basetypes.NewBoolValue(false)
-	hostState.HostFlags.EnvironSet.Override = basetypes.NewBoolValue(false)
-	hostState.HostFlags.OpenVMS.Enabled = basetypes.NewBoolValue(false)
-	hostState.HostFlags.OpenVMS.Override = basetypes.NewBoolValue(false)
-	hostState.HostFlags.SCSISupport1.Enabled = basetypes.NewBoolValue(false)
-	hostState.HostFlags.SCSISupport1.Override = basetypes.NewBoolValue(false)
-	hostState.HostFlags.SCSI3.Enabled = basetypes.NewBoolValue(false)
-	hostState.HostFlags.SCSI3.Override = basetypes.NewBoolValue(false)
-	hostState.HostFlags.Spc2ProtocolVersion.Enabled = basetypes.NewBoolValue(false)
-	hostState.HostFlags.Spc2ProtocolVersion.Override = basetypes.NewBoolValue(false)
+	hostState.HostFlags = &models.HostFlags{
+		VolumeSetAddressing: models.HostFlag{
+			Enabled:  basetypes.NewBoolValue(false),
+			Override: basetypes.NewBoolValue(false),
+		},
+		DisableQResetOnUA: models.HostFlag{
+			Enabled:  basetypes.NewBoolValue(false),
+			Override: basetypes.NewBoolValue(false),
+		},
+		EnvironSet: models.HostFlag{
+			Enabled:  basetypes.NewBoolValue(false),
+			Override: basetypes.NewBoolValue(false),
+		},
+		AvoidResetBroadcast: models.HostFlag{
+			Enabled:  basetypes.NewBoolValue(false),
+			Override: basetypes.NewBoolValue(false),
+		},
+		OpenVMS: models.HostFlag{
+			Enabled:  basetypes.NewBoolValue(false),
+			Override: basetypes.NewBoolValue(false),
+		},
+		SCSI3: models.HostFlag{
+			Enabled:  basetypes.NewBoolValue(false),
+			Override: basetypes.NewBoolValue(false),
+		},
+		Spc2ProtocolVersion: models.HostFlag{
+			Enabled:  basetypes.NewBoolValue(false),
+			Override: basetypes.NewBoolValue(false),
+		},
+		SCSISupport1: models.HostFlag{
+			Enabled:  basetypes.NewBoolValue(false),
+			Override: basetypes.NewBoolValue(false),
+		},
+	}
 }
 
 func saveHgListAttribute(hostGroupState *models.HostGroupModel, listAttribute []string, attributeName string) {
@@ -277,4 +295,80 @@ func HostGroupDetailMapper(hg *pmaxTypes.HostGroup) (models.HostGroupDetailModal
 		}
 	}
 	return model, err
+}
+
+// HandleHostFlag Sets the hostflag state in the plan if there is not one there by default, otherwise use what is in the plan.
+func HandleHostFlag(plan models.HostGroupModel) pmaxTypes.HostFlags {
+	if plan.HostFlags == nil {
+		return pmaxTypes.HostFlags{
+			VolumeSetAddressing: &pmaxTypes.HostFlag{
+				Enabled:  false,
+				Override: false,
+			},
+			DisableQResetOnUA: &pmaxTypes.HostFlag{
+				Enabled:  false,
+				Override: false,
+			},
+			EnvironSet: &pmaxTypes.HostFlag{
+				Enabled:  false,
+				Override: false,
+			},
+			AvoidResetBroadcast: &pmaxTypes.HostFlag{
+				Enabled:  false,
+				Override: false,
+			},
+			OpenVMS: &pmaxTypes.HostFlag{
+				Enabled:  false,
+				Override: false,
+			},
+			SCSI3: &pmaxTypes.HostFlag{
+				Enabled:  false,
+				Override: false,
+			},
+			Spc2ProtocolVersion: &pmaxTypes.HostFlag{
+				Enabled:  false,
+				Override: false,
+			},
+			SCSISupport1: &pmaxTypes.HostFlag{
+				Enabled:  false,
+				Override: false,
+			},
+			ConsistentLUN: plan.ConsistentLun.ValueBool(),
+		}
+	}
+	return pmaxTypes.HostFlags{
+		VolumeSetAddressing: &pmaxTypes.HostFlag{
+			Enabled:  plan.HostFlags.VolumeSetAddressing.Enabled.ValueBool(),
+			Override: plan.HostFlags.VolumeSetAddressing.Override.ValueBool(),
+		},
+		DisableQResetOnUA: &pmaxTypes.HostFlag{
+			Enabled:  plan.HostFlags.DisableQResetOnUA.Enabled.ValueBool(),
+			Override: plan.HostFlags.DisableQResetOnUA.Override.ValueBool(),
+		},
+		EnvironSet: &pmaxTypes.HostFlag{
+			Enabled:  plan.HostFlags.EnvironSet.Enabled.ValueBool(),
+			Override: plan.HostFlags.EnvironSet.Override.ValueBool(),
+		},
+		AvoidResetBroadcast: &pmaxTypes.HostFlag{
+			Enabled:  plan.HostFlags.AvoidResetBroadcast.Enabled.ValueBool(),
+			Override: plan.HostFlags.AvoidResetBroadcast.Override.ValueBool(),
+		},
+		OpenVMS: &pmaxTypes.HostFlag{
+			Enabled:  plan.HostFlags.OpenVMS.Enabled.ValueBool(),
+			Override: plan.HostFlags.OpenVMS.Override.ValueBool(),
+		},
+		SCSI3: &pmaxTypes.HostFlag{
+			Enabled:  plan.HostFlags.SCSI3.Enabled.ValueBool(),
+			Override: plan.HostFlags.SCSI3.Override.ValueBool(),
+		},
+		Spc2ProtocolVersion: &pmaxTypes.HostFlag{
+			Enabled:  plan.HostFlags.Spc2ProtocolVersion.Enabled.ValueBool(),
+			Override: plan.HostFlags.Spc2ProtocolVersion.Override.ValueBool(),
+		},
+		SCSISupport1: &pmaxTypes.HostFlag{
+			Enabled:  plan.HostFlags.SCSISupport1.Enabled.ValueBool(),
+			Override: plan.HostFlags.SCSISupport1.Override.ValueBool(),
+		},
+		ConsistentLUN: plan.ConsistentLun.ValueBool(),
+	}
 }

--- a/powermax/helper/portgroup_helper.go
+++ b/powermax/helper/portgroup_helper.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
-// GetPmaxPortsFromTfsdkPG returns a slice of pmaxTypes.PortKey from a models.PortGroup
+// GetPmaxPortsFromTfsdkPG returns a slice of pmaxTypes.PortKey from a models.PortGroup.
 func GetPmaxPortsFromTfsdkPG(tfsdkPg models.PortGroup) []pmaxTypes.PortKey {
 
 	if len(tfsdkPg.Ports) > 0 {
@@ -33,7 +33,7 @@ func GetPmaxPortsFromTfsdkPG(tfsdkPg models.PortGroup) []pmaxTypes.PortKey {
 	return nil
 }
 
-// UpdatePGState updates the state of a PortGroup
+// UpdatePGState updates the state of a PortGroup.
 func UpdatePGState(pgState, pgPlan *models.PortGroup, pgResponse *pmaxTypes.PortGroup) {
 	pgState.ID = types.StringValue(pgResponse.PortGroupID)
 	pgState.Name = types.StringValue(pgResponse.PortGroupID)
@@ -97,7 +97,7 @@ func UpdatePGState(pgState, pgPlan *models.PortGroup, pgResponse *pmaxTypes.Port
 
 }
 
-// UpdatePortGroup updates a PortGroup and returns a slice of updated parameters, failed parameters and error messages
+// UpdatePortGroup updates a PortGroup and returns a slice of updated parameters, failed parameters and error messages.
 func UpdatePortGroup(ctx context.Context, client client.Client, planPg, statePg models.PortGroup) (updatedParams []string, updateFailedParams []string, errorMessages []string) {
 	planPorts := GetPmaxPortsFromTfsdkPG(planPg)
 	statePorts := GetPmaxPortsFromTfsdkPG(statePg)

--- a/powermax/models/host_group.go
+++ b/powermax/models/host_group.go
@@ -11,7 +11,7 @@ type HostGroupModel struct {
 	// Name - The name of the hostgroup
 	Name types.String `tfsdk:"name"`
 	// HostFlags - Specifies the flags set for a hostgroup
-	HostFlags HostFlags `tfsdk:"host_flags"`
+	HostFlags *HostFlags `tfsdk:"host_flags"`
 	// ConsistentLun - Specifies whether the consistent_lun flag is set or not for a hostgroup
 	ConsistentLun types.Bool `tfsdk:"consistent_lun"`
 	// HostIDs - Specifies the host IDs associated with the hostgroup


### PR DESCRIPTION
# Description
A few sentences describing the overall goals of the pull request's commits.
    - Should set default host flags with a provider configuration which does
      not have them set.
    - Should show host group error if host_id is set to empty string value
      before requesting from the Array.

These are the valid configurations
```
resource "powermax_hostgroup" "test_host_group" {
  # Optional
  host_flags = {
  }
  host_ids = ["testHost"]
  name     = "host_group"
}
```
*or without the host_flags parameter, it will default everything to false for the flags*
```
resource "powermax_hostgroup" "test_host_group" {
  host_ids = ["testHost"]
  name     = "host_group"
}
```

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/terraform-provider-powermax/issues/47|

# ISSUE TYPE

- Bugfix Pull Request

##### RESOURCE OR DATASOURCE NAME
Host Group

##### OUTPUT
<!--- Paste the functionality test result below -->
```
TF_ACC=1 go test -count=1 -v -run TestAccHostGroupResource
ok      terraform-provider-powermax/powermax/provider   104.692s
```
# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility