### PR TITLE
HostGroup Flag Modify Fix

### DIFF
--- a/powermax/helper/hostgroup_helper.go
+++ b/powermax/helper/hostgroup_helper.go
@@ -162,7 +162,7 @@ func UpdateHostGroup(ctx context.Context, client client.Client, plan, state mode
 		}
 	}
 
-	if plan.HostFlags != state.HostFlags || plan.ConsistentLun.ValueBool() != state.ConsistentLun.ValueBool() {
+	if *plan.HostFlags != *state.HostFlags || plan.ConsistentLun.ValueBool() != state.ConsistentLun.ValueBool() {
 		hostFlags := pmaxTypes.HostFlags{
 			VolumeSetAddressing: &pmaxTypes.HostFlag{
 				Enabled:  plan.HostFlags.VolumeSetAddressing.Enabled.ValueBool(),

--- a/powermax/provider/hostgroup_datasource_test.go
+++ b/powermax/provider/hostgroup_datasource_test.go
@@ -18,7 +18,6 @@ func TestAccHostGroupDatasource(t *testing.T) {
 			{
 				Config: ProviderConfig + HostGroupDataSourceParamsAll,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(hostGroupName, "host_group_details.#", "8"),
 					resource.TestCheckResourceAttr(hostGroupName, "filter.#", "0"),
 				),
 			},

--- a/powermax/provider/hostgroup_resource.go
+++ b/powermax/provider/hostgroup_resource.go
@@ -332,7 +332,8 @@ func (r *HostGroup) Create(ctx context.Context, req resource.CreateRequest, resp
 	newHostGroup, err := r.client.PmaxClient.CreateHostGroup(ctx, r.client.SymmetrixID, plan.Name.ValueString(), hostIds, &hostFlags)
 	if err != nil {
 		hostgroupID := plan.Name.ValueString()
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create host group, got error: %s", err.Error()))
+		resp.Diagnostics.AddError("Client Error", "Unable to create host group, please make sure only existing host(s) are set in the host_id flag")
+		tflog.Debug(ctx, err.Error())
 		//Attempt to remove any partially created obejcts if there are any
 		hostGroupResponse, getHostGroupErr := r.client.PmaxClient.GetHostGroupByID(ctx, r.client.SymmetrixID, hostgroupID)
 		if hostGroupResponse != nil || getHostGroupErr == nil {

--- a/powermax/provider/hostgroup_resource_test.go
+++ b/powermax/provider/hostgroup_resource_test.go
@@ -206,6 +206,44 @@ func TestAccHostGroupResourceNoHostFlagShouldStillWork(t *testing.T) {
 	})
 }
 
+func TestAccHostGroupResourceUpdateNoFlag(t *testing.T) {
+	var hostGroupTerraformName = "powermax_hostgroup.test_hostgroup"
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: ProviderConfig + `
+				resource "powermax_hostgroup" "test_hostgroup" {
+				  host_ids = ["tfacc_host_group_host"]
+				  name     = "test_host_group_no_flag"
+				}
+				`,
+			},
+			{
+				Config: ProviderConfig + `
+				resource "powermax_hostgroup" "test_hostgroup" {
+				  host_ids = ["tfacc_host_group_host", "tfacc_host_group_host_2"]
+				  name     = "tfacc_host_group_update_no_flag"
+				}
+				`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(hostGroupTerraformName, "host_ids.#", "2"),
+					// Verify the name
+					resource.TestCheckResourceAttr(hostGroupTerraformName, "name", "tfacc_host_group_update_no_flag"),
+					// Verify Calculated values
+					// numofmaskingviews
+					resource.TestCheckResourceAttr(hostGroupTerraformName, "numofmaskingviews", "0"),
+					// numofinitiators
+					resource.TestCheckResourceAttr(hostGroupTerraformName, "numofinitiators", "0"),
+					// numofhosts
+					resource.TestCheckResourceAttr(hostGroupTerraformName, "numofhosts", "2"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccHostGroupResourceError(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },

--- a/powermax/provider/portgroup_data_source_test.go
+++ b/powermax/provider/portgroup_data_source_test.go
@@ -37,11 +37,11 @@ func TestAccPortGroupDatasourceFilteredError(t *testing.T) {
 	})
 }
 
-// List a specific portgroup
+// List a specific portgroup.
 var PortGroupDataSourceFilterError = `
 data "powermax_portgroups" "errgroups" {
   filter {
-    names = ["tfacc_test1_fibre", "non-existant-port-group"]
+    names = ["tfacc_test1_fibre", "non-existent-port-group"]
   }
 }`
 

--- a/powermax/provider/portgroup_resource_test.go
+++ b/powermax/provider/portgroup_resource_test.go
@@ -97,7 +97,7 @@ func TestAccPortGroupResourceError(t *testing.T) {
 	})
 }
 
-// List a specific portgroup
+// List a specific portgroup.
 var PortGroupRourceError = `
 resource "powermax_portgroup" "test_portgroup" {
 	name = "tfacc_error"

--- a/powermax/provider/provider_test.go
+++ b/powermax/provider/provider_test.go
@@ -25,7 +25,7 @@ var testAccProtoV6ProviderFactories = map[string]func() (tfprotov6.ProviderServe
 var ProviderConfig = ""
 var FunctionMocker *Mocker
 
-// for acc test, avoid conflict of existing resources
+// for acc test, avoid conflict of existing resources.
 var ResourceSuffix = RandResNameSuffix(5)
 
 func init() {

--- a/powermax/provider/storagegroup_resource.go
+++ b/powermax/provider/storagegroup_resource.go
@@ -5,17 +5,18 @@ package provider
 import (
 	"context"
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-framework/attr"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"terraform-provider-powermax/client"
 	"terraform-provider-powermax/powermax/helper"
 	"terraform-provider-powermax/powermax/models"
 
 	pmaxTypes "github.com/dell/gopowermax/v2/types/v100"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )


### PR DESCRIPTION
# Description
- When updating the HostGroup properties without modifying the host flags it was showing an error.


# ISSUE TYPE
- Bugfix Pull Request

##### RESOURCE OR DATASOURCE NAME
HostGroup Resource 

##### OUTPUT
```

```
##### ADDITIONAL INFORMATION
```
TF_ACC=1 go test -count=1 -v -run TestAccHostGroupResource
=== RUN   TestAccHostGroupResource
    provider_test.go:74:
                        provider "powermax" {
                                username      = "smc"
                                password      = "smc"
                                endpoint      = "http://localhost:3000"
                                serial_number = "smc"
                                pmax_version  = "100"
                                insecure      = true
                        }

time="2023-05-30T13:29:14-04:00" level=info msg="payload: {\"hostGroupId\":\"test_host_group\",\"hostId\":[\"tfacc_host_group_host\"],\"hostFlags\":{\"volume_set_addressing\":{\"enabled\":false,\"override\":fal\":{\"enabled\":false,\"override\":false},\"environ_set\":{\"enabled\":false,\"override\":false},\"avoid_reset_broadcast\":{\"enabled\":true,\"override\":true},\"openvms\":{\"enabled\":false,\"override\":false}lse,\"override\":false},\"spc2_protocol_version\":{\"enabled\":false,\"override\":false},\"scsi_support1\":{\"enabled\":false,\"override\":false},\"consistent_lun\":false},\"executionOption\":\"SYNCHRONOUS\"}"
time="2023-05-30T13:29:14-04:00" level=info msg="Successfully created HostGroup: test_host_group"
time="2023-05-30T13:29:29-04:00" level=info msg="payload: {\"editHostGroupActionParam\":{\"addHostParam\":{\"host\":[\"tfacc_host_group_host_2\"]}},\"executionOption\":\"SYNCHRONOUS\"}"
time="2023-05-30T13:29:29-04:00" level=info msg="payload: {\"editHostGroupActionParam\":{\"renameHostGroupParam\":{\"new_host_group_name\":\"test_host_group_update\"}},\"executionOption\":\"SYNCHRONOUS\"}"
time="2023-05-30T13:29:35-04:00" level=info msg="Successfully deleted HostGroup: test_host_group_update"
--- PASS: TestAccHostGroupResource (25.44s)
=== RUN   TestAccHostGroupResourceEmptyHostIdInList
    provider_test.go:74:
                        provider "powermax" {
                                username      = "smc"
                                password      = "smc"
                                endpoint      = "http://localhost:3000"
                                serial_number = "smc"
                                pmax_version  = "100"
                                insecure      = true
                        }

--- PASS: TestAccHostGroupResourceEmptyHostIdInList (4.66s)
=== RUN   TestAccHostGroupResourceNoHostFlagShouldStillWork
    provider_test.go:74:
                        provider "powermax" {
                                username      = "smc"
                                password      = "smc"
                                endpoint      = "http://localhost:3000"
                                serial_number = "smc"
                                pmax_version  = "100"
                                insecure      = true
                        }

time="2023-05-30T13:29:44-04:00" level=info msg="payload: {\"hostGroupId\":\"test_host_group_no_flag\",\"hostId\":[\"tfacc_host_group_host\"],\"hostFlags\":{\"volume_set_addressing\":{\"enabled\":false,\"overriet_on_ua\":{\"enabled\":false,\"override\":false},\"environ_set\":{\"enabled\":false,\"override\":false},\"avoid_reset_broadcast\":{\"enabled\":false,\"override\":false},\"openvms\":{\"enabled\":false,\"overridabled\":false,\"override\":false},\"spc2_protocol_version\":{\"enabled\":false,\"override\":false},\"scsi_support1\":{\"enabled\":false,\"override\":false},\"consistent_lun\":false},\"executionOption\":\"SYNCHR
time="2023-05-30T13:29:44-04:00" level=info msg="Successfully created HostGroup: test_host_group_no_flag"
time="2023-05-30T13:29:50-04:00" level=info msg="Successfully deleted HostGroup: test_host_group_no_flag"
--- PASS: TestAccHostGroupResourceNoHostFlagShouldStillWork (10.83s)
=== RUN   TestAccHostGroupResourceUpdateNoFlag
    provider_test.go:74:
                        provider "powermax" {
                                username      = "smc"
                                password      = "smc"
                                endpoint      = "http://localhost:3000"
                                serial_number = "smc"
                                pmax_version  = "100"
                                insecure      = true
                        }

time="2023-05-30T13:29:55-04:00" level=info msg="payload: {\"hostGroupId\":\"test_host_group_no_flag\",\"hostId\":[\"tfacc_host_group_host\"],\"hostFlags\":{\"volume_set_addressing\":{\"enabled\":false,\"overriet_on_ua\":{\"enabled\":false,\"override\":false},\"environ_set\":{\"enabled\":false,\"override\":false},\"avoid_reset_broadcast\":{\"enabled\":false,\"override\":false},\"openvms\":{\"enabled\":false,\"overridabled\":false,\"override\":false},\"spc2_protocol_version\":{\"enabled\":false,\"override\":false},\"scsi_support1\":{\"enabled\":false,\"override\":false},\"consistent_lun\":false},\"executionOption\":\"SYNCHR
time="2023-05-30T13:29:55-04:00" level=info msg="Successfully created HostGroup: test_host_group_no_flag"
time="2023-05-30T13:30:04-04:00" level=info msg="payload: {\"editHostGroupActionParam\":{\"addHostParam\":{\"host\":[\"tfacc_host_group_host_2\"]}},\"executionOption\":\"SYNCHRONOUS\"}"
time="2023-05-30T13:30:04-04:00" level=info msg="payload: {\"editHostGroupActionParam\":{\"renameHostGroupParam\":{\"new_host_group_name\":\"tfacc_host_group_update_no_flag\"}},\"executionOption\":\"SYNCHRONOUS
time="2023-05-30T13:30:10-04:00" level=info msg="Successfully deleted HostGroup: tfacc_host_group_update_no_flag"
--- PASS: TestAccHostGroupResourceUpdateNoFlag (19.76s)
=== RUN   TestAccHostGroupResourceError
    provider_test.go:74:
                        provider "powermax" {
                                username      = "smc"
                                password      = "smc"
                                endpoint      = "http://localhost:3000"
                                serial_number = "smc"
                                pmax_version  = "100"
                                insecure      = true
                        }

time="2023-05-30T13:30:15-04:00" level=info msg="payload: {\"hostGroupId\":\"tfacc_host_group_err\",\"hostId\":[\"tfacc_host_group_host\"],\"hostFlags\":{\"volume_set_addressing\":{\"enabled\":false,\"override\on_ua\":{\"enabled\":true,\"override\":true},\"environ_set\":{\"enabled\":false,\"override\":false},\"avoid_reset_broadcast\":{\"enabled\":true,\"override\":true},\"openvms\":{\"enabled\":false,\"override\":fal:false,\"override\":false},\"spc2_protocol_version\":{\"enabled\":false,\"override\":false},\"scsi_support1\":{\"enabled\":false,\"override\":false},\"consistent_lun\":false},\"executionOption\":\"SYNCHRONOUS\"
time="2023-05-30T13:30:15-04:00" level=info msg="Successfully created HostGroup: tfacc_host_group_err"
time="2023-05-30T13:30:24-04:00" level=info msg="payload: {\"hostGroupId\":\"tfacc_host_group_err\",\"hostId\":[\"tfacc_host_group_host\"],\"hostFlags\":{\"volume_set_addressing\":{\"enabled\":false,\"override\on_ua\":{\"enabled\":false,\"override\":false},\"environ_set\":{\"enabled\":false,\"override\":false},\"avoid_reset_broadcast\":{\"enabled\":true,\"override\":true},\"openvms\":{\"enabled\":false,\"override\":f\":false,\"override\":false},\"spc2_protocol_version\":{\"enabled\":false,\"override\":false},\"scsi_support1\":{\"enabled\":false,\"override\":false},\"consistent_lun\":false},\"executionOption\":\"SYNCHRONOUS
time="2023-05-30T13:30:24-04:00" level=info msg="Successfully deleted HostGroup: tfacc_host_group_err"
time="2023-05-30T13:30:24-04:00" level=error msg="CreateHostGroup failed: Not Found"
time="2023-05-30T13:30:24-04:00" level=info msg="Successfully deleted Host: tfacc_host_group_err"
time="2023-05-30T13:30:26-04:00" level=error msg="GetHostGroupByID failed: Not Found"
--- PASS: TestAccHostGroupResourceError (16.31s)
PASS
ok      terraform-provider-powermax/powermax/provider   78.627s
```
# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility