### PR TITLE
Add Portgroup validator

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -63,8 +63,10 @@ func NewOpenApiClient(ctx context.Context, endpoint, username, password, serialN
 		Jar:     jar,
 	}
 	if insecure {
+		/* #nosec */
 		httpclient.Transport = &http.Transport{
 			TLSClientConfig: &tls.Config{
+				MinVersion:         tls.VersionTLS12,
 				InsecureSkipVerify: true,
 			},
 		}
@@ -77,6 +79,7 @@ func NewOpenApiClient(ctx context.Context, endpoint, username, password, serialN
 		}
 		httpclient.Transport = &http.Transport{
 			TLSClientConfig: &tls.Config{
+				MinVersion:         tls.VersionTLS12,
 				RootCAs:            pool,
 				InsecureSkipVerify: false,
 			},
@@ -104,7 +107,6 @@ func NewOpenApiClient(ctx context.Context, endpoint, username, password, serialN
 	if serialNumber != "" {
 		cfg.AddDefaultHeader("symid", serialNumber)
 	}
-	fmt.Printf("config %+v header %+v", cfg, cfg.DefaultHeader)
 
 	apiClient := pmaxop.NewAPIClient(cfg)
 	return apiClient, nil

--- a/docs/resources/portgroup.md
+++ b/docs/resources/portgroup.md
@@ -47,9 +47,9 @@ resource "powermax_portgroup" "portgroup_1" {
 
 ### Required
 
-- `name` (String) The name of the portgroup.
+- `name` (String) The name of the portgroup. Only alphanumeric characters, underscores ( _ ), and hyphens (-) are allowed.
 - `ports` (Attributes List) The list of ports associated with the portgroup. (see [below for nested schema](#nestedatt--ports))
-- `protocol` (String) The portgroup protocol.
+- `protocol` (String) The portgroup protocol. Protocols: SCSI_FC, iSCSI, NVMe_FC, NVMe_TCP
 
 ### Read-Only
 

--- a/powermax/helper/portgroup_helper.go
+++ b/powermax/helper/portgroup_helper.go
@@ -243,9 +243,8 @@ func updatePortGroupParams(ctx context.Context, client client.Client, portGroupI
 
 func modifyPortGroup(ctx context.Context, client client.Client, portGroupID string, edit pmax.EditPortGroupActionParam) (*pmax.PortGroup, bool, error) {
 	modifyParam := client.PmaxOpenapiClient.SLOProvisioningApi.ModifyPortGroup(ctx, client.SymmetrixID, portGroupID)
-	modifyParam = modifyParam.EditPortGroupParam(pmax.EditPortGroupParam{
-		EditPortGroupActionParam: edit,
-	})
+	editParam := pmax.NewEditPortGroupParam(edit)
+	modifyParam = modifyParam.EditPortGroupParam(*editParam)
 	pgResponse, resp1, err := client.PmaxOpenapiClient.SLOProvisioningApi.ModifyPortGroupExecute(modifyParam)
 	if err != nil {
 		return pgResponse, true, err

--- a/powermax/provider/portgroup_resource.go
+++ b/powermax/provider/portgroup_resource.go
@@ -21,15 +21,18 @@ import (
 	"context"
 	pmax "dell/powermax-go-client"
 	"fmt"
+	"regexp"
 	"strings"
 	"terraform-provider-powermax/client"
 	"terraform-provider-powermax/powermax/constants"
 	"terraform-provider-powermax/powermax/helper"
 	"terraform-provider-powermax/powermax/models"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
@@ -66,8 +69,16 @@ func (r *PortGroup) Schema(ctx context.Context, req resource.SchemaRequest, resp
 			},
 			"name": schema.StringAttribute{
 				Required:            true,
-				Description:         "The name of the portgroup.",
-				MarkdownDescription: "The name of the portgroup.",
+				Description:         "The name of the portgroup. Only alphanumeric characters, underscores ( _ ), and hyphens (-) are allowed.",
+				MarkdownDescription: "The name of the portgroup. Only alphanumeric characters, underscores ( _ ), and hyphens (-) are allowed.",
+				Validators: []validator.String{
+					stringvalidator.LengthAtLeast(1),
+					stringvalidator.LengthAtMost(64),
+					stringvalidator.RegexMatches(
+						regexp.MustCompile(`^[a-zA-Z0-9_-]*$`),
+						"must contain only alphanumeric characters and _-",
+					),
+				},
 			},
 			"ports": schema.ListNestedAttribute{
 				Required: true,
@@ -86,8 +97,11 @@ func (r *PortGroup) Schema(ctx context.Context, req resource.SchemaRequest, resp
 			},
 			"protocol": schema.StringAttribute{
 				Required:            true,
-				Description:         "The portgroup protocol.",
-				MarkdownDescription: "The portgroup protocol.",
+				Description:         "The portgroup protocol. Protocols: SCSI_FC, iSCSI, NVMe_FC, NVMe_TCP",
+				MarkdownDescription: "The portgroup protocol. Protocols: SCSI_FC, iSCSI, NVMe_FC, NVMe_TCP",
+				Validators: []validator.String{
+					stringvalidator.OneOf("SCSI_FC", "iSCSI", "NVMe_FC", "NVMe_TCP"),
+				},
 			},
 			"numofports": schema.Int64Attribute{
 				Computed:            true,


### PR DESCRIPTION
# Description
Add validator for Portgroup Name and protocol properties

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue #84 |
| -------------- |
| |

# ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### RESOURCE OR DATASOURCE NAME
<!--- Write the short name of the resource or datasource below -->

##### OUTPUT
<!--- Paste the functionality test result below -->
```paste below
powermax tf_rpc=ApplyResourceChange tf_req_id=7faac8ca-1565-0d18-d184-d36b853fca6b
--- PASS: TestAccPortgroupResource (26.78s)
PASS
ok      terraform-provider-powermax/powermax/provider   32.325s

```
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 80% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility


# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Unit tests
- [x] Acceptance tests