### PR TITLE
Snapshot policy add/remove Storage Groups

### DIFF
--- a/docs/resources/snapshotpolicy.md
+++ b/docs/resources/snapshotpolicy.md
@@ -49,6 +49,9 @@ resource "powermax_snapshotpolicy" "terraform_sp" {
 
   interval = "2 Hours"
 
+  // should only be set for modify/edit operation , not supported during create
+  # storage_groups =  ["tfacc_sp_sg1", "tfacc_sp_sg2"]
+
   // Default values defined for some of the optional Fields
   # interval             = "1 Hour"
   # snapshot_count       = "48"
@@ -79,6 +82,7 @@ resource "powermax_snapshotpolicy" "terraform_sp" {
 - `retention_days` (Number) The number of days that snapshots will be retained in the cloud for. Only applies to cloud policies
 - `secure` (Boolean) Set if the snapshot policy creates secure snapshots
 - `snapshot_count` (Number) Number of snapshots that will be taken before the oldest ones are no longer required
+- `storage_groups` (Set of String) The storage groups associated with the snapshot policy..This field cannot be set during create and is only valid for Edit/Update.
 - `suspended` (Boolean) Set if the snapshot policy has been suspended
 
 ### Read-Only

--- a/examples/resources/powermax_snapshotpolicy/resource.tf
+++ b/examples/resources/powermax_snapshotpolicy/resource.tf
@@ -17,6 +17,9 @@ resource "powermax_snapshotpolicy" "terraform_sp" {
 
   interval = "2 Hours"
 
+  // should only be set for modify/edit operation , not supported during create
+  # storage_groups =  ["tfacc_sp_sg1", "tfacc_sp_sg2"]
+
   // Default values defined for some of the optional Fields
   # interval             = "1 Hour"
   # snapshot_count       = "48"

--- a/powermax/models/snapshot_policy.go
+++ b/powermax/models/snapshot_policy.go
@@ -95,4 +95,6 @@ type SnapshotPolicyResource struct {
 	ComplianceCountCritical types.Int64 `tfsdk:"compliance_count_critical"`
 	// The type of Snapshots that are created with the policy, local or cloud.
 	Type types.String `tfsdk:"type"`
+	// Storage Groups associated with the snapshot policy
+	StorageGroups types.Set `tfsdk:"storage_groups"`
 }

--- a/powermax/provider/snapshotpolicy_resource_test.go
+++ b/powermax/provider/snapshotpolicy_resource_test.go
@@ -58,6 +58,30 @@ func TestAccSnapshotPolicyResource(t *testing.T) {
 					resource.TestCheckResourceAttr(snapPolicyTerraformName, "type", "local"),
 				),
 			},
+			// Add storage Groups to Snapshot Policy
+			{
+				Config: ProviderConfig + SnapshotPolicyResourceSGAdd,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(snapPolicyTerraformName, "snapshot_policy_name", "terraform_test_sp_add"),
+					resource.TestCheckResourceAttr(snapPolicyTerraformName, "interval", "1 Day"),
+					resource.TestCheckResourceAttr(snapPolicyTerraformName, "compliance_count_critical", "29"),
+					resource.TestCheckResourceAttr(snapPolicyTerraformName, "compliance_count_warning", "47"),
+					resource.TestCheckResourceAttr(snapPolicyTerraformName, "type", "local"),
+					resource.TestCheckResourceAttr(snapPolicyTerraformName, "storage_groups.#", "2"),
+				),
+			},
+			// Remove storage Groups from Snapshot Policy
+			{
+				Config: ProviderConfig + SnapshotPolicyResourceSGRemove,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(snapPolicyTerraformName, "snapshot_policy_name", "terraform_test_sp_remove"),
+					resource.TestCheckResourceAttr(snapPolicyTerraformName, "interval", "1 Day"),
+					resource.TestCheckResourceAttr(snapPolicyTerraformName, "compliance_count_critical", "29"),
+					resource.TestCheckResourceAttr(snapPolicyTerraformName, "compliance_count_warning", "47"),
+					resource.TestCheckResourceAttr(snapPolicyTerraformName, "type", "local"),
+					resource.TestCheckResourceAttr(snapPolicyTerraformName, "storage_groups.#", "0"),
+				),
+			},
 			// Delete testing automatically occurs in TestCase
 		},
 	})
@@ -93,5 +117,21 @@ resource "powermax_snapshotpolicy" "terraform_test_sp" {
 	snapshot_policy_name = "terraform_test_sp1"
 	interval = "1 Day"
 	compliance_count_critical = 29
+  }
+`
+var SnapshotPolicyResourceSGAdd = `
+resource "powermax_snapshotpolicy" "terraform_test_sp" {
+	snapshot_policy_name = "terraform_test_sp_add"
+	interval = "1 Day"
+	compliance_count_critical = 29
+	storage_groups = ["tfacc_sp_sg1", "tfacc_sp_sg2"]
+  }
+`
+var SnapshotPolicyResourceSGRemove = `
+resource "powermax_snapshotpolicy" "terraform_test_sp" {
+	snapshot_policy_name = "terraform_test_sp_remove"
+	interval = "1 Day"
+	compliance_count_critical = 29
+	storage_groups = []
   }
 `


### PR DESCRIPTION
# Description
Allow users to add/remove storage group from snapshot policy

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |


# ISSUE TYPE
- Feature Pull Request

##### RESOURCE OR DATASOURCE NAME
Snapshot policy

##### OUTPUT
![snapPolResTest](https://github.com/dell/terraform-provider-powermax/assets/131491094/0e8abea5-517f-4f1c-9620-8720050d1f23)


# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 80% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility


# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Unit tests
- [x] Acceptance tests