### PR TITLE
Remove associated SGs on snapshot Policy delete

### DIFF
--- a/docs/resources/snapshotpolicy.md
+++ b/docs/resources/snapshotpolicy.md
@@ -49,7 +49,8 @@ resource "powermax_snapshotpolicy" "terraform_sp" {
 
   interval = "2 Hours"
 
-  // should only be set for modify/edit operation , not supported during create
+  // should only be set for modify/edit operation , not supported during create. 
+  // Also the destroy/delete will also unlink any associted storage groups from Snapshot Policy before deleting the snapshot policy.
   # storage_groups =  ["tfacc_sp_sg1", "tfacc_sp_sg2"]
 
   // Default values defined for some of the optional Fields
@@ -82,7 +83,7 @@ resource "powermax_snapshotpolicy" "terraform_sp" {
 - `retention_days` (Number) The number of days that snapshots will be retained in the cloud for. Only applies to cloud policies
 - `secure` (Boolean) Set if the snapshot policy creates secure snapshots
 - `snapshot_count` (Number) Number of snapshots that will be taken before the oldest ones are no longer required
-- `storage_groups` (Set of String) The storage groups associated with the snapshot policy..This field cannot be set during create and is only valid for Edit/Update.
+- `storage_groups` (Set of String) The storage groups associated with the snapshot policy..This field cannot be set during create and is only valid for Edit/Update.If user wants to delete the snapshot policy all associated storage groups will also be unlinked from the Snapshot Policy.
 - `suspended` (Boolean) Set if the snapshot policy has been suspended
 
 ### Read-Only

--- a/examples/resources/powermax_snapshotpolicy/resource.tf
+++ b/examples/resources/powermax_snapshotpolicy/resource.tf
@@ -17,7 +17,8 @@ resource "powermax_snapshotpolicy" "terraform_sp" {
 
   interval = "2 Hours"
 
-  // should only be set for modify/edit operation , not supported during create
+  // should only be set for modify/edit operation , not supported during create. 
+  // Also the destroy/delete will also unlink any associted storage groups from Snapshot Policy before deleting the snapshot policy.
   # storage_groups =  ["tfacc_sp_sg1", "tfacc_sp_sg2"]
 
   // Default values defined for some of the optional Fields


### PR DESCRIPTION
# Description
Destroy/delete should also remove any associated storage groups from Snapshot Policy

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# ISSUE TYPE
- Bugfix Pull Request


##### RESOURCE OR DATASOURCE NAME
Snapshot Policy Resource

##### OUTPUT
![sptest](https://github.com/dell/terraform-provider-powermax/assets/131491094/e1d6fbcf-1b97-44e9-bec0-9f07a7624840)

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 80% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility


# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Unit tests
- [x] Acceptance tests