### PR TITLE
Fix Longevity Tests Issues

### DIFF
--- a/powermax/provider/snapshot_resource_test.go
+++ b/powermax/provider/snapshot_resource_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
-func TestAccSnapshotResource(t *testing.T) {
+func TestAccSnapshotResourceA(t *testing.T) {
 	var snapshotTerraformName = "powermax_snapshot.test"
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
@@ -35,7 +35,7 @@ func TestAccSnapshotResource(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Create and Read testing
 			{
-				Config: ProviderConfig + SnapshotResourceConfig,
+				Config: ProviderConfig + SnapshotResourcNoTTLeConfig,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(snapshotTerraformName, "name", "tfacc_snapshot_1"),
 					resource.TestCheckResourceAttr(snapshotTerraformName, "linked_storage_group.#", "0"),
@@ -286,6 +286,18 @@ resource "powermax_snapshot" "test" {
 }
 `
 
+var SnapshotResourcNoTTLeConfig = `
+resource "powermax_snapshot" "test" {
+	storage_group {
+		name = "tfacc_sg_snapshot"
+	}
+	snapshot_actions {
+		# Required, name of new snapshot
+		name = "tfacc_snapshot_1"
+	}
+}
+`
+
 var SnapshotResourceConfig = `
 resource "powermax_snapshot" "test" {
 	storage_group {
@@ -294,6 +306,11 @@ resource "powermax_snapshot" "test" {
 	snapshot_actions {
 		# Required, name of new snapshot
 		name = "tfacc_snapshot_1"
+		time_to_live = {
+			enable = true
+			time_in_hours = true
+			time_to_live = 1
+		}
 	}
 }
 `


### PR DESCRIPTION
# Description
- Longevity Tests were leaving stale resources on the PowerMax which was causing some errors in the tests after a few days of constant testing. This makes it so the Volume and Snapshot resources are cleaned up properly during each test.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# ISSUE TYPE
- Bugfix Pull Request

##### RESOURCE OR DATASOURCE NAME
Snapshot and Volume 

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 80% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility


# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Unit tests
- [x] Acceptance tests