### PR TITLE
Fix Port Protocol Inconsistency Issue

### DIFF
--- a/powermax/helper/portgroup_helper.go
+++ b/powermax/helper/portgroup_helper.go
@@ -99,11 +99,8 @@ func CreatePortGroup(ctx context.Context, client client.Client, plan models.Port
 func UpdatePGState(pgState, pgPlan *models.PortGroup, pgResponse *pmax.PortGroup) {
 	pgState.ID = types.StringValue(pgResponse.PortGroupId)
 	pgState.Name = types.StringValue(pgResponse.PortGroupId)
-	if portGroupProtocol, ok := pgResponse.GetPortGroupProtocolOk(); ok {
-		pgState.Protocol = types.StringValue(*portGroupProtocol)
-	} else {
-		pgState.Protocol = pgPlan.Protocol
-	}
+	// Always use the state protocol to avoid Response collisions
+	pgState.Protocol = pgPlan.Protocol
 
 	if portGroupNoMaskingview, ok := pgResponse.GetNumOfMaskingViewsOk(); ok {
 		pgState.NumOfMaskingViews = types.Int64Value(*portGroupNoMaskingview)


### PR DESCRIPTION
# Description
- Fix Response inconsistency issue in PowerMax 10.2 between Port_Group protocol. 

# ISSUE TYPE
- Bugfix Pull Request

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 80% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility


# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x]FT tests